### PR TITLE
Modernisation: changes for udisksctl and more recent rupor-minimal.7z

### DIFF
--- a/00_check_prerequisites
+++ b/00_check_prerequisites
@@ -9,7 +9,7 @@ explain "Checking prerequisites.."
 
 check_command minicom
 check_command 7z
-check_command udisks
+check_command udisksctl
 check_command curl
 check_command bspatch
 

--- a/10_download_packages
+++ b/10_download_packages
@@ -8,11 +8,11 @@ source ./common.sh
 cd packages
 explain "Downloading packages..."
 
-curl -O "http://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/rescue/20121010/rupor-rescue.7z"
-curl -O "http://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/jailbreak/20121016/rupor-jailbreak.7z"
-curl -O "http://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/20121222/rupor-minimal.7z"
-curl -O "http://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/adb/20121211/rupor-enable-adb.7z"
-curl -O "http://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/apps2sd/20121211/rupor-enable-asec.7z"
+curl -O "https://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/rescue/20121010/rupor-rescue.7z"
+curl -O "https://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/jailbreak/20121016/rupor-jailbreak.7z"
+curl -O "https://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/20130107/rupor-minimal.7z"
+curl -O "https://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/adb/20121211/rupor-enable-adb.7z"
+curl -O "https://projects.mobileread.com/reader/users/porkupan/rupor/ReleasesT2/apps2sd/20121211/rupor-enable-asec.7z"
 
 explain "Checking integrity..."
 md5sum -c ../packages.md5sums

--- a/30_backup
+++ b/30_backup
@@ -13,12 +13,12 @@ abort "Step needs review. Disabled."
 TARGET_DEV=""
 
 for DEV in /dev/sd?; do
-    if udisks --show-info $DEV | grep PRS-T2 >/dev/null; then
+    if udisksctl info -b $DEV | grep PRS-T2 >/dev/null; then
         echo "Reader found but not in recovery mode. Exiting.";
         exit 1
     fi
 
-    if udisks --show-info $DEV | grep PRS-XXX >/dev/null; then
+    if udisksctl info -b $DEV | grep PRS-XXX >/dev/null; then
         TARGET_DEV=$DEV
     fi
 done
@@ -34,7 +34,7 @@ fi
 ############################################################
 # Extra safety checks
 
-if [ ! udisks --show-info $TARGET_DEV | egrep 'count:\s+10$' ]; then
+if [ ! udisksctl info -b $TARGET_DEV | egrep 'count:\s+10$' ]; then
     echo "Partition count differs than expected. Exiting."
     exit 1
 fi

--- a/common.sh
+++ b/common.sh
@@ -54,12 +54,12 @@ check_command() {
 
 detect_disk_reader() {
     for DEV in /dev/sd?; do
-        if udisks --show-info $DEV | grep PRS-XXX >/dev/null; then
+        if udisksctl info -b $DEV | grep PRS-XXX >/dev/null; then
             abort "Reader found but in recovery mode. Reboot in normal mode and retry."
         fi
         
-        if udisks --show-info $DEV | egrep 'model:\s+PRS-T2$' >/dev/null; then
-            if udisks --show-info $DEV | egrep 'label:\s+READER$' >/dev/null; then
+        if udisksctl info -b $DEV | egrep 'drives/Sony_PRS_T2_' >/dev/null; then
+            if udisksctl info -b $DEV | egrep 'IdLabel:\s+READER$' >/dev/null; then
                 echo $DEV
                 return 0
             fi
@@ -69,8 +69,8 @@ detect_disk_reader() {
 
 detect_disk_sd() {
     for DEV in /dev/sd??; do
-        if udisks --show-info $DEV | grep 'by-id/usb-Sony_PRS-T2_SD' >/dev/null; then
-            if udisks --show-info $DEV | grep 'partition:$' >/dev/null; then
+        if udisksctl info -b $DEV | grep 'by-id/usb-Sony_PRS-T2_SD' >/dev/null; then
+            if udisksctl info -b $DEV | grep 'Partition:$' >/dev/null; then
                 echo $DEV
                 return 0
             fi
@@ -81,25 +81,26 @@ detect_disk_sd() {
 
 prs_mount_reader() {
     DEV=$(detect_disk_reader)
-    udisks --mount $DEV >/dev/null
-    udisks --show-info $DEV | grep 'mount paths:' | tr -d ' ' | cut -d: -f2
+    udisksctl mount -b $DEV >/dev/null
+    udisksctl info -b $DEV | grep 'MountPoints:' | tr -d ' ' | cut -d: -f2
 }
 
 prs_unmount_reader() {
     sync
     DEV=$(detect_disk_reader)
-    udisks --unmount $DEV
+    udisksctl unmount -b $DEV
 }
 
 prs_mount_sd() {
     DEV=$(detect_disk_sd) || return 1
 
-    udisks --mount $DEV >/dev/null || return 1
-    udisks --show-info $DEV | grep 'mount paths:' | tr -d ' ' | cut -d: -f2
+    udisksctl unmount -b $DEV >/dev/null
+    udisksctl mount -b $DEV >/dev/null || return 1
+    udisksctl info -b $DEV | grep 'MountPoints:' | tr -d ' ' | cut -d: -f2
 }
 
 prs_unmount_sd() {
     sync
     DEV=$(detect_disk_sd) || return 1
-    udisks --unmount $DEV
+    udisksctl unmount -b $DEV
 }

--- a/common.sh
+++ b/common.sh
@@ -95,6 +95,7 @@ prs_mount_sd() {
     DEV=$(detect_disk_sd) || return 1
 
     udisksctl unmount -b $DEV >/dev/null
+
     udisksctl mount -b $DEV >/dev/null || return 1
     udisksctl info -b $DEV | grep 'MountPoints:' | tr -d ' ' | cut -d: -f2
 }

--- a/packages.md5sums
+++ b/packages.md5sums
@@ -1,5 +1,5 @@
 faa58a7dc585cbd6067755a6a603396c  rupor-rescue.7z
 c4fa3a58b29d2a04160208832b56d682  rupor-jailbreak.7z
-ee597ff4ec249ba5629774869ad949ca  rupor-minimal.7z
+d7a6be509a36ab56f87d4e362986a79d  rupor-minimal.7z
 f6aff2ef13138fca8bbebb02d0f7840e  rupor-enable-adb.7z
 1429f957addfc2a55779da8dc2a18cc2  rupor-enable-asec.7z


### PR DESCRIPTION
These changes are self explanatory. 

- the new command `udisksctl` takes different format arguments
- the new command `udisksctl` has different format output, so grep patterns had to be changed
- unmount forced before mount just to make sure
- the `rupor-minimal.7z` referenced has been replaced with the latest version

I've not been able to get my PRS-T2 into recovery mode so at this time this is only partially tested.